### PR TITLE
Use current version of opencsv, update deprecated code, clean lint, and add support for newlines.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
   <version>1.1.2-0.11.0</version>
   <dependencies>
     <dependency>
-      <groupId>net.sf.opencsv</groupId>
+      <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
-      <version>2.3</version>
+      <version>3.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/src/main/java/com/bizo/hive/serde/csv/CSVSerde.java
+++ b/src/main/java/com/bizo/hive/serde/csv/CSVSerde.java
@@ -130,7 +130,7 @@ public final class CSVSerde extends AbstractSerDe {
 
       for (int i=0; i< numCols; i++) {
         if (read != null && i < read.length) {
-          row.set(i, read[i]);
+          row.set(i, read[i].toString().replace("\r\n", "<CRLF>").replace("\r", "<CR>").replace("\n","<LF>"));
         } else {
           row.set(i, null);
         }

--- a/src/main/java/com/bizo/hive/serde/csv/CSVSerde.java
+++ b/src/main/java/com/bizo/hive/serde/csv/CSVSerde.java
@@ -130,7 +130,7 @@ public final class CSVSerde extends AbstractSerDe {
 
       for (int i=0; i< numCols; i++) {
         if (read != null && i < read.length) {
-          row.set(i, read[i].toString().replace("\r\n", "<CRLF>").replace("\r", "<CR>").replace("\n","<LF>"));
+          row.set(i, read[i].replace("\r\n", "<CRLF>").replace("\r", "<CR>").replace("\n","<LF>"));
         } else {
           row.set(i, null);
         }

--- a/src/main/java/com/bizo/hive/serde/csv/CSVSerde.java
+++ b/src/main/java/com/bizo/hive/serde/csv/CSVSerde.java
@@ -151,8 +151,6 @@ public final class CSVSerde extends AbstractSerDe {
   }
   
   private CSVReader newReader(final Reader reader, char separator, char quote, char escape) {
-    // CSVReader will throw an exception if any of separator, quote, or escape is the same, but 
-    // the CSV format specifies that the escape character and quote char are the same... very weird
     if (CSVWriter.DEFAULT_ESCAPE_CHARACTER == escape) {
       return new CSVReader(reader, separator, quote);
     } else {

--- a/src/main/java/com/bizo/hive/serde/csv/CSVSerde.java
+++ b/src/main/java/com/bizo/hive/serde/csv/CSVSerde.java
@@ -11,8 +11,8 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde.Constants;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -26,8 +26,8 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 
-import au.com.bytecode.opencsv.CSVReader;
-import au.com.bytecode.opencsv.CSVWriter;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVWriter;
 
 
 /**
@@ -35,7 +35,7 @@ import au.com.bytecode.opencsv.CSVWriter;
  * 
  * @author Larry Ogrodnek <ogrodnek@gmail.com>
  */
-public final class CSVSerde implements SerDe {
+public final class CSVSerde extends AbstractSerDe {
   
   private ObjectInspector inspector;
   private String[] outputFields;
@@ -49,8 +49,8 @@ public final class CSVSerde implements SerDe {
     
   @Override
   public void initialize(final Configuration conf, final Properties tbl) throws SerDeException {
-    final List<String> columnNames = Arrays.asList(tbl.getProperty(Constants.LIST_COLUMNS).split(","));
-    final List<TypeInfo> columnTypes = TypeInfoUtils.getTypeInfosFromTypeString(tbl.getProperty(Constants.LIST_COLUMN_TYPES));
+    final List<String> columnNames = Arrays.asList(tbl.getProperty(serdeConstants.LIST_COLUMNS).split(","));
+    final List<TypeInfo> columnTypes = TypeInfoUtils.getTypeInfosFromTypeString(tbl.getProperty(serdeConstants.LIST_COLUMN_TYPES));
     
     numCols = columnNames.size();
     

--- a/src/test/java/com/bizo/hive/serde/csv/CSVSerdeTest.java
+++ b/src/test/java/com/bizo/hive/serde/csv/CSVSerdeTest.java
@@ -30,7 +30,7 @@ public final class CSVSerdeTest {
     assertEquals("hello", row.get(0));
     assertEquals("yes, okay", row.get(1));
     assertEquals("1", row.get(2));
-    assertEquals("new\nline", row.get(3));
+    assertEquals("new<LF>line", row.get(3));
   }
 
   @Test
@@ -40,13 +40,13 @@ public final class CSVSerdeTest {
 
     csv.initialize(null, props);
 
-    final Text in = new Text("hello\t'yes\tokay'\t1\t'new\nline'");
+    final Text in = new Text("hello\t'yes\tokay'\t1\t'new\n\nline'");
     final List<String> row = (List<String>) csv.deserialize(in);
 
     assertEquals("hello", row.get(0));
     assertEquals("yes\tokay", row.get(1));
     assertEquals("1", row.get(2));
-    assertEquals("new\nline", row.get(3));
+    assertEquals("new<LF><LF>line", row.get(3));
   }
 
   @Test
@@ -56,13 +56,19 @@ public final class CSVSerdeTest {
 
     csv.initialize(null, props);
 
-    final Text in = new Text("hello,'yes\\'okay',1,\'new\nline\'");
+    final Text in = new Text("hello,'yes\\'okay',1,'new\r\nline'");
     final List<String> row = (List<String>) csv.deserialize(in);
 
     assertEquals("hello", row.get(0));
     assertEquals("yes'okay", row.get(1));
     assertEquals("1", row.get(2));
-    assertEquals("new\nline", row.get(3));
+// A bug in opencsv is causing carriage returns to be stripped. 
+// When this bug is resolved, the assertion below will be replaced
+// with the commented-out version below it. 
+// CSVSerde code will not need changed.
+// See https://sourceforge.net/p/opencsv/bugs/106.
+    assertEquals("new<LF>line", row.get(3));
+//    assertEquals("new<CRLF>line", row.get(3));
   }
 
   @Test
@@ -73,12 +79,18 @@ public final class CSVSerdeTest {
 
     csv.initialize(null, props);
 
-    final Text in = new Text("hello,\"yes, okay\",1,\"new\n\"\"line\"\"\"");
+    final Text in = new Text("hello,\"yes, okay\",1,\"new\r\n\r\n\"\"line\"\"\"");
     final List<String> row = (List<String>) csv.deserialize(in);
 
     assertEquals("hello", row.get(0));
     assertEquals("yes, okay", row.get(1));
     assertEquals("1", row.get(2));
-    assertEquals("new\n\"line\"", row.get(3));
+// A bug in opencsv is causing carriage returns to be stripped. 
+// When this bug is resolved, the assertion below will be replaced
+// with the commented-out version below it.
+// CSVSerde code will not need changed.
+// See https://sourceforge.net/p/opencsv/bugs/106.
+    assertEquals("new<LF><LF>\"line\"", row.get(3));
+//    assertEquals("new<CRLF><CRLF>\"line\"", row.get(3));
   }
 }

--- a/src/test/java/com/bizo/hive/serde/csv/CSVSerdeTest.java
+++ b/src/test/java/com/bizo/hive/serde/csv/CSVSerdeTest.java
@@ -3,7 +3,7 @@ package com.bizo.hive.serde.csv;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.hadoop.hive.serde.Constants;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.io.Text;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,20 +16,21 @@ public final class CSVSerdeTest {
   
   @Before
   public void setup() throws Exception {
-    props.put(Constants.LIST_COLUMNS, "a,b,c");
-    props.put(Constants.LIST_COLUMN_TYPES, "string,string,string");
+    props.put(serdeConstants.LIST_COLUMNS, "a,b,c,d");
+    props.put(serdeConstants.LIST_COLUMN_TYPES, "string,string,string,string");
   }
   
   @Test
   public void testDeserialize() throws Exception {
     csv.initialize(null, props);    
-    final Text in = new Text("hello,\"yes, okay\",1");
+    final Text in = new Text("hello,\"yes, okay\",1,new\nline");
     
     final List<String> row = (List<String>) csv.deserialize(in);
 
     assertEquals("hello", row.get(0));
     assertEquals("yes, okay", row.get(1));
     assertEquals("1", row.get(2));
+    assertEquals("new\nline", row.get(3));
   }
   
   
@@ -40,12 +41,13 @@ public final class CSVSerdeTest {
     
     csv.initialize(null, props);
     
-    final Text in = new Text("hello\t'yes\tokay'\t1");
+    final Text in = new Text("hello\t'yes\tokay'\t1\tnew\nline");
     final List<String> row = (List<String>) csv.deserialize(in);
         
     assertEquals("hello", row.get(0));
     assertEquals("yes\tokay", row.get(1));    
     assertEquals("1", row.get(2));
+    assertEquals("new\nline", row.get(3));
   }
   
   @Test
@@ -55,11 +57,12 @@ public final class CSVSerdeTest {
     
     csv.initialize(null, props);
     
-    final Text in = new Text("hello,'yes\\'okay',1");
+    final Text in = new Text("hello,'yes\\'okay',1,new\nline");
     final List<String> row = (List<String>) csv.deserialize(in);
         
     assertEquals("hello", row.get(0));
     assertEquals("yes'okay", row.get(1));
     assertEquals("1", row.get(2));
+    assertEquals("new\nline", row.get(3));
   }  
 }

--- a/src/test/java/com/bizo/hive/serde/csv/CSVSerdeTest.java
+++ b/src/test/java/com/bizo/hive/serde/csv/CSVSerdeTest.java
@@ -23,7 +23,7 @@ public final class CSVSerdeTest {
   @Test
   public void testDeserialize() throws Exception {
     csv.initialize(null, props);    
-    final Text in = new Text("hello,\"yes, okay\",1,new\nline");
+    final Text in = new Text("hello,\"yes, okay\",1,\"new\nline\"");
     
     final List<String> row = (List<String>) csv.deserialize(in);
 
@@ -41,7 +41,7 @@ public final class CSVSerdeTest {
     
     csv.initialize(null, props);
     
-    final Text in = new Text("hello\t'yes\tokay'\t1\tnew\nline");
+    final Text in = new Text("hello\t'yes\tokay'\t1\t'new\nline'");
     final List<String> row = (List<String>) csv.deserialize(in);
         
     assertEquals("hello", row.get(0));
@@ -57,7 +57,7 @@ public final class CSVSerdeTest {
     
     csv.initialize(null, props);
     
-    final Text in = new Text("hello,'yes\\'okay',1,new\nline");
+    final Text in = new Text("hello,'yes\\'okay',1,\'new\nline\'");
     final List<String> row = (List<String>) csv.deserialize(in);
         
     assertEquals("hello", row.get(0));

--- a/src/test/java/com/bizo/hive/serde/csv/CSVSerdeTest.java
+++ b/src/test/java/com/bizo/hive/serde/csv/CSVSerdeTest.java
@@ -12,19 +12,19 @@ import static org.junit.Assert.assertEquals;
 
 public final class CSVSerdeTest {
   private final CSVSerde csv = new CSVSerde();
-  final Properties props = new Properties();  
-  
+  final Properties props = new Properties();
+
   @Before
   public void setup() throws Exception {
     props.put(serdeConstants.LIST_COLUMNS, "a,b,c,d");
     props.put(serdeConstants.LIST_COLUMN_TYPES, "string,string,string,string");
   }
-  
+
   @Test
   public void testDeserialize() throws Exception {
-    csv.initialize(null, props);    
+    csv.initialize(null, props);
+
     final Text in = new Text("hello,\"yes, okay\",1,\"new\nline\"");
-    
     final List<String> row = (List<String>) csv.deserialize(in);
 
     assertEquals("hello", row.get(0));
@@ -32,37 +32,53 @@ public final class CSVSerdeTest {
     assertEquals("1", row.get(2));
     assertEquals("new\nline", row.get(3));
   }
-  
-  
+
   @Test
-  public void testDeserializeCustomSeparators() throws Exception {
+  public void testDeserializeCustomSeparator() throws Exception {
     props.put("separatorChar", "\t");
     props.put("quoteChar", "'");
-    
+
     csv.initialize(null, props);
-    
+
     final Text in = new Text("hello\t'yes\tokay'\t1\t'new\nline'");
     final List<String> row = (List<String>) csv.deserialize(in);
-        
+
     assertEquals("hello", row.get(0));
-    assertEquals("yes\tokay", row.get(1));    
+    assertEquals("yes\tokay", row.get(1));
     assertEquals("1", row.get(2));
     assertEquals("new\nline", row.get(3));
   }
-  
+
   @Test
   public void testDeserializeCustomEscape() throws Exception {
     props.put("quoteChar", "'");
     props.put("escapeChar", "\\");
-    
+
     csv.initialize(null, props);
-    
+
     final Text in = new Text("hello,'yes\\'okay',1,\'new\nline\'");
     final List<String> row = (List<String>) csv.deserialize(in);
-        
+
     assertEquals("hello", row.get(0));
     assertEquals("yes'okay", row.get(1));
     assertEquals("1", row.get(2));
     assertEquals("new\nline", row.get(3));
-  }  
+  }
+
+  @Test
+  public void testDeserializeCustomSeparatorCustomEscape() throws Exception {
+    props.put("seperatorChar", ",");
+    props.put("quoteChar", "\"");
+    props.put("escapeChar", "\"");
+
+    csv.initialize(null, props);
+
+    final Text in = new Text("hello,\"yes, okay\",1,\"new\n\"\"line\"\"\"");
+    final List<String> row = (List<String>) csv.deserialize(in);
+
+    assertEquals("hello", row.get(0));
+    assertEquals("yes, okay", row.get(1));
+    assertEquals("1", row.get(2));
+    assertEquals("new\n\"line\"", row.get(3));
+  }
 }


### PR DESCRIPTION
This request is rather large, sorry about that. Before submitting this pull request, I ran tests using Hive versions 0.11.0 through 0.14.0 in the pom--all passed. Note Hive 0.14.0 dependencies do not [resolve automatically](https://stackoverflow.com/questions/27710049/hive-0-14-udf-maven-project-missing-dependencies).

Here is a summary of the small changes I made.
- Updated pom to use latest version of opencsv. Before this change version 2.3 from 2011 was being used.
- Removed extraneous spaces at the end of lines.
- Replace org.apache.hadoop.hive.serde.Constants and org.apache.hadoop.hive.serde2.SerDe with current equivalents. Both have been deprecated [since Hive 0.11.0](https://hive.apache.org/javadocs/r0.11.0/api/deprecated-list.html).
- Added testDeserializeCustomSeparatorCustomEscape(), which shows using the same escape and quote chars does not result in an exception. (Line 77 of CSVSerdeTest). Removed comments around Line 154 of CSVSerde.

Finally, a summary of why I am submitting this pull request in the first place. opencsv does an alright job of managing embedded line breaks in csv files ([it strips carriage returns and breaks that are not \n](https://sourceforge.net/p/opencsv/bugs/106/)), but using this SerDe with Hive results in NULLs after every row containing a line break. I've included tests and code that will take \n, \r, and \r\n and output them as <LF>, <CR>, and <CRLF> respectively. I've singled out these breaks because they're the only ones defined in the csv standard.

Let me know what you think. Maybe we can put our heads together and solve things like #18 and #3.